### PR TITLE
Change puli command timeout from 60s to 180s

### DIFF
--- a/src/PuliRunner.php
+++ b/src/PuliRunner.php
@@ -75,6 +75,7 @@ class PuliRunner
         $fullCommand = sprintf('%s %s --no-ansi -vv', $this->puli, $command);
 
         $process = new Process($fullCommand);
+        $process->setTimeout( 180 );
         $process->run();
 
         if (!$process->isSuccessful()) {


### PR DESCRIPTION
Puli build is timing out during composer update/install as it's going over the default 60s timeout. This PR increases the timeout to 3 minutes from 1.