### PR TITLE
Require puli/composer-plugin on Windows

### DIFF
--- a/src/PuliPlugin.php
+++ b/src/PuliPlugin.php
@@ -75,7 +75,7 @@ class PuliPlugin implements PluginInterface, EventSubscriberInterface
     public function __construct(PuliRunner $puliRunner = null)
     {
         $this->puliRunner = $puliRunner;
-        $this->rootDir = getcwd();
+        $this->rootDir = Path::canonicalize(getcwd());
     }
 
     /**
@@ -466,10 +466,10 @@ class PuliPlugin implements PluginInterface, EventSubscriberInterface
         $packages = array();
 
         $output = $this->puliRunner->run(
-            'package --list --format \'%name%;%installer%;%install_path%;%state%\''
+            'package --list --format "%name%;%installer%;%install_path%;%state%"'
         );
 
-        foreach (explode("\n", $output) as $packageLine) {
+        foreach (explode(PHP_EOL, $output) as $packageLine) {
             if (!$packageLine) {
                 continue;
             }

--- a/src/PuliRunner.php
+++ b/src/PuliRunner.php
@@ -60,7 +60,7 @@ class PuliRunner
             }
         }
 
-        if (Path::hasExtension($puli, '.bat')) {
+        if (Path::hasExtension($puli, '.bat', true)) {
             $this->puli = $puli;
         } else {
             $this->puli = $php.' '.$puli;

--- a/tests/PuliPluginTest.php
+++ b/tests/PuliPluginTest.php
@@ -203,7 +203,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n"
             );
@@ -254,7 +254,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n"
             );
@@ -285,7 +285,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n"
             );
@@ -320,7 +320,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n"
             );
@@ -344,7 +344,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n".
                 "vendor/package2;composer;{$this->tempDir}/package2;enabled\n"
@@ -384,7 +384,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n".
                 "vendor/package1;spock;{$this->tempDir}/package1;enabled\n"
@@ -417,9 +417,9 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->once())
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willThrowException(new PuliRunnerException(
-                "package --list --format '%name%;%installer%;%install_path%;%state%'",
+                'package --list --format "%name%;%installer%;%install_path%;%state%"',
                 1,
                 'FileNotFoundException: The file foobar does not exist.',
                 'Exception trace...'
@@ -438,7 +438,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n".
                 "vendor/package1;composer;{$this->tempDir}/package1;not-loadable\n".
@@ -460,7 +460,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n".
                 "vendor/package1;spock;{$this->tempDir}/package1;not-loadable\n".
@@ -483,7 +483,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n".
                 "vendor/package1;composer;{$this->tempDir}/package1;not-found\n".
@@ -505,7 +505,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n".
                 "vendor/package1;spock;{$this->tempDir}/package1;not-found\n".
@@ -536,7 +536,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n".
                 "vendor/package1;composer;{$this->tempDir}/package1;enabled\n".
@@ -571,7 +571,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n".
                 "vendor/package1;composer;{$this->tempDir}/package1/sub/path;enabled\n".
@@ -599,7 +599,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n".
                 "vendor/package1;composer;{$this->tempDir}/package1;enabled\n"
@@ -627,7 +627,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n".
                 "vendor/package1;composer;{$this->tempDir}/package1/sub/path;enabled\n".
@@ -662,7 +662,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n".
                 "vendor/package1;composer;{$this->tempDir}/package1/sub/path;enabled\n".
@@ -705,7 +705,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n".
                 "vendor/package1;composer;{$this->tempDir}/package1;enabled\n".
@@ -732,7 +732,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n".
                 "vendor/package1;spock;{$this->tempDir}/package1;not-found\n"
@@ -766,7 +766,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n".
                 "vendor/package1;composer;{$this->tempDir}/package1;enabled\n".
@@ -799,7 +799,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/previous;;{$this->tempDir};enabled\n"
             );
@@ -824,7 +824,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/root;;{$this->tempDir};enabled\n"
             );
@@ -847,7 +847,7 @@ class PuliPluginTest extends PHPUnit_Framework_TestCase
 
         $this->puliRunner->expects($this->at(0))
             ->method('run')
-            ->with("package --list --format '%name%;%installer%;%install_path%;%state%'")
+            ->with('package --list --format "%name%;%installer%;%install_path%;%state%"')
             ->willReturn(
                 "vendor/previous;;{$this->tempDir};enabled\n"
             );


### PR DESCRIPTION
I just add `"puli/composer-plugin": "^1.0@beta"` to the `composer.json`
file, then run `composer update`. I got a weird output:

```
Generating PULI_FACTORY_CLASS constant
Registering @ECHO OFF
SET BIN_TARGET=%~dp0/../vendor/puli/cli/bin/puli
php "%BIN_TARGET%" %* with the class-map autoloader
Looking for updated Puli packages
```
I find why. On Windows, the .bat file is run under php and not directly.
So  it only print the file script content instand of print the result of
the .bat exec.

After fix that, I got another error, due to Windows and its EOL. Change
"\n" by PHP_EOL resolve this.

And the last one (due to Windows to?), run a command with single quotes
using PuliRunner add quotes to the first and the last arguments. Using
double quote work well. I try to understand why but did not found (run
the command from the shell work fine both with single and double
quotes).