### PR TITLE
Fix PuliRunner when not using phar

### DIFF
--- a/src/PuliRunner.php
+++ b/src/PuliRunner.php
@@ -15,6 +15,7 @@ use RuntimeException;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
+use Webmozart\PathUtil\Path;
 
 /**
  * Executes the "puli" command.
@@ -59,7 +60,11 @@ class PuliRunner
             }
         }
 
-        $this->puli = $php.' '.$puli;
+        if (Path::hasExtension($puli, '.bat')) {
+            $this->puli = $puli;
+        } else {
+            $this->puli = $php.' '.$puli;
+        }
     }
 
     /**


### PR DESCRIPTION
The PuliRunner class run bat and sh script using php. Add a check to be
sure to run only phar with php.

First referance to this bug in #14. I made a second PR to seperate Windows quote concern and this problem with PuliRunner cause this is not depending on the OS.

I will make the #14 PR only for Windows quote problem.
